### PR TITLE
FIX to ignore directories, not just their contents

### DIFF
--- a/GDM/SSAutoGitIgnore/UpdateScript.php
+++ b/GDM/SSAutoGitIgnore/UpdateScript.php
@@ -12,7 +12,7 @@ class UpdateScript {
         $packageInfo = new SSPackageInfo($event->getComposer());
         $ignores     = array();
         foreach ($packageInfo->GetSSModules() as $value) {
-            $ignores[] = "/" . $value["path"] . "/";
+            $ignores[] = "/" . $value["path"] ;//. "/";
         }
         sort($ignores);
 


### PR DESCRIPTION
Using eGit in eclipse, the trailing slash is causing folders to not be excluded.