### PR TITLE
Remove duplicate lines

### DIFF
--- a/GDM/SSAutoGitIgnore/UpdateScript.php
+++ b/GDM/SSAutoGitIgnore/UpdateScript.php
@@ -14,6 +14,7 @@ class UpdateScript {
         foreach ($packageInfo->GetSSModules() as $value) {
             $ignores[] = "/" . $value["path"] ;//. "/";
         }
+        $ignores = array_unique($ignores);
         sort($ignores);
 
         $gi->setLines($ignores);


### PR DESCRIPTION
It may happen that the set of installed packages require packages that declare same installation path. This causes the same path to be output multiple times into the generated .gitignore file.

This minor non-BC change is fixing that.