### PR TITLE
Add spacing around git auto rules to keep .gitignore clean

### DIFF
--- a/GDM/SSAutoGitIgnore/GitIgnoreEditor.php
+++ b/GDM/SSAutoGitIgnore/GitIgnoreEditor.php
@@ -155,11 +155,17 @@ class GitIgnoreEditor {
     /**
      * Save chanes to the .gitinore file
      *
-     * @throws type
+     * @throws AutoGitIgnoreSaveFailedException
      * @return self
      */
     public function save() {
         $this->CheckGitIgnore();
+        if (!empty($this->beforeLines) && trim(end($this->beforeLines))) {
+            array_push($this->beforeLines, '');
+        }
+        if (empty($this->afterLines) || trim(reset($this->afterLines))) {
+            array_unshift($this->afterLines, '');
+        }
         $this->readLines = array_merge($this->beforeLines, $this->autoLines, $this->afterLines);
         if (count($this->readLines)) {
             if (!file_put_contents($this->filePath, implode(PHP_EOL, $this->readLines))) {


### PR DESCRIPTION
It bugs me that the default `.gitignore` from https://github.com/silverstripe/silverstripe-installer has nice spacing around each set of rules but the rules added by this module doesn't.

This patch adds a new line before and after the rule set to keep the spacing as intended.